### PR TITLE
added graphql mutation and query for PickupActivity

### DIFF
--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/controllers/gql/GraphQLMutation.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/controllers/gql/GraphQLMutation.java
@@ -1,6 +1,7 @@
 package com.irdaislakhuafa.garbagepickupapi.controllers.gql;
 
 import com.irdaislakhuafa.garbagepickupapi.controllers.gql.pickup.PickupMutation;
+import com.irdaislakhuafa.garbagepickupapi.controllers.gql.pickupactivity.PickupActivityMutation;
 import com.irdaislakhuafa.garbagepickupapi.controllers.gql.role.RoleMutation;
 import com.irdaislakhuafa.garbagepickupapi.controllers.gql.trashtype.TrashTypeMutation;
 import com.irdaislakhuafa.garbagepickupapi.controllers.gql.user.UserMutation;
@@ -20,6 +21,7 @@ public class GraphQLMutation {
     private final TrashTypeMutation trashType;
     private final VoucherMutation voucher;
     private final UserVoucherMutation userVoucher;
+    private final PickupActivityMutation pickupActivity;
 
     @SchemaMapping(field = "user")
     public UserMutation user() {
@@ -49,5 +51,10 @@ public class GraphQLMutation {
     @SchemaMapping(field = "userVoucher")
     public UserVoucherMutation userVoucher() {
         return this.userVoucher;
+    }
+
+    @SchemaMapping(field = "pickupActivity")
+    public PickupActivityMutation pickupActivity() {
+        return this.pickupActivity;
     }
 }

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/controllers/gql/GraphQLQuery.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/controllers/gql/GraphQLQuery.java
@@ -2,6 +2,7 @@ package com.irdaislakhuafa.garbagepickupapi.controllers.gql;
 
 import com.irdaislakhuafa.garbagepickupapi.controllers.gql.hello.HelloQuery;
 import com.irdaislakhuafa.garbagepickupapi.controllers.gql.pickup.PickupQuery;
+import com.irdaislakhuafa.garbagepickupapi.controllers.gql.pickupactivity.PickupActivityQuery;
 import com.irdaislakhuafa.garbagepickupapi.controllers.gql.trashtype.TrashTypeQuery;
 import com.irdaislakhuafa.garbagepickupapi.controllers.gql.user.UserQuery;
 import com.irdaislakhuafa.garbagepickupapi.controllers.gql.uservoucher.UserVoucherQuery;
@@ -20,6 +21,7 @@ public class GraphQLQuery {
     private final PickupQuery pickup;
     private final VoucherQuery voucher;
     private final UserVoucherQuery userVoucher;
+    private final PickupActivityQuery pickupActivity;
 
     @SchemaMapping(field = "hello")
     public HelloQuery helloQuery() {
@@ -49,5 +51,10 @@ public class GraphQLQuery {
     @SchemaMapping(field = "userVoucher")
     public UserVoucherQuery userVoucher() {
         return this.userVoucher;
+    }
+
+    @SchemaMapping(field = "pickupActivity")
+    public PickupActivityQuery pickupActivity() {
+        return this.pickupActivity;
     }
 }

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/controllers/gql/pickupactivity/PickupActivityMutation.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/controllers/gql/pickupactivity/PickupActivityMutation.java
@@ -1,0 +1,25 @@
+package com.irdaislakhuafa.garbagepickupapi.controllers.gql.pickupactivity;
+
+import com.irdaislakhuafa.garbagepickupapi.models.entities.PickupActivity;
+import com.irdaislakhuafa.garbagepickupapi.models.gql.request.pickupactivity.PickupActivityRequest;
+import com.irdaislakhuafa.garbagepickupapi.services.PickupActivityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.SchemaMapping;
+import org.springframework.stereotype.Controller;
+
+import java.util.Optional;
+
+@Controller
+@RequiredArgsConstructor
+@SchemaMapping(typeName = "PickupActivityMutation")
+public class PickupActivityMutation {
+    private final PickupActivityService pickupActivityService;
+
+    @SchemaMapping
+    public Optional<PickupActivity> save(@Argument(name = "request") PickupActivityRequest request) {
+        final var pickupActivity = this.pickupActivityService.fromRequestToEntity(request);
+        final var result = this.pickupActivityService.save(pickupActivity);
+        return result;
+    }
+}

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/controllers/gql/pickupactivity/PickupActivityQuery.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/controllers/gql/pickupactivity/PickupActivityQuery.java
@@ -1,0 +1,29 @@
+package com.irdaislakhuafa.garbagepickupapi.controllers.gql.pickupactivity;
+
+import com.irdaislakhuafa.garbagepickupapi.models.entities.PickupActivity;
+import com.irdaislakhuafa.garbagepickupapi.services.PickupActivityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.SchemaMapping;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@SchemaMapping(typeName = "PickupActivityQuery")
+public class PickupActivityQuery {
+    private final PickupActivityService pickupActivityService;
+
+    @SchemaMapping
+    public List<PickupActivity> findAllByPickupId(@Argument(name = "pickupId") String pickupId) {
+        final var results = this.pickupActivityService.findAllByPickupId(pickupId);
+        return results;
+    }
+
+    @SchemaMapping
+    public List<PickupActivity> findAllByPickupResi(@Argument(name = "pickupResi") String pickupResi) {
+        final var results = this.pickupActivityService.findAllByPickupResi(pickupResi);
+        return results;
+    }
+}

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/models/gql/request/pickupactivity/PickupActivityRequest.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/models/gql/request/pickupactivity/PickupActivityRequest.java
@@ -1,0 +1,15 @@
+package com.irdaislakhuafa.garbagepickupapi.models.gql.request.pickupactivity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class PickupActivityRequest {
+    private String pickupId;
+    private String description;
+}

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/models/gql/request/pickupactivity/PickupActivityUpdateRequest.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/models/gql/request/pickupactivity/PickupActivityUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.irdaislakhuafa.garbagepickupapi.models.gql.request.pickupactivity;
+
+public class PickupActivityUpdateRequest {
+    private String id;
+    private String description;
+}

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/repository/PickupActivityRepository.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/repository/PickupActivityRepository.java
@@ -3,5 +3,10 @@ package com.irdaislakhuafa.garbagepickupapi.repository;
 import com.irdaislakhuafa.garbagepickupapi.models.entities.PickupActivity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PickupActivityRepository extends JpaRepository<PickupActivity, PickupActivityRepository> {
+    List<PickupActivity> findAllByPickupId(String pickupId);
+
+    List<PickupActivity> findAllByPickupResi(String pickupResi);
 }

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/repository/PickupActivityRepository.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/repository/PickupActivityRepository.java
@@ -1,0 +1,7 @@
+package com.irdaislakhuafa.garbagepickupapi.repository;
+
+import com.irdaislakhuafa.garbagepickupapi.models.entities.PickupActivity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PickupActivityRepository extends JpaRepository<PickupActivity, PickupActivityRepository> {
+}

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/PickupActivityService.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/PickupActivityService.java
@@ -12,4 +12,8 @@ public interface PickupActivityService extends CRUDService<PickupActivity, Strin
     List<PickupActivity> findAllByPickupId(final String pickupId);
 
     List<PickupActivity> findAllByPickupResi(String pickupResi);
+
+//    List<PickupActivity> findAllByPickupId(final String pickupId, sortBy);
+
+//    List<PickupActivity> findAllByPickupResi(String pickupResi, sortBy);
 }

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/PickupActivityService.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/PickupActivityService.java
@@ -1,0 +1,7 @@
+package com.irdaislakhuafa.garbagepickupapi.services;
+
+import com.irdaislakhuafa.garbagepickupapi.models.entities.Pickup;
+import com.irdaislakhuafa.garbagepickupapi.services.converter.CRUDService;
+
+public interface PickupActivityService extends CRUDService<Pickup, String> {
+}

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/PickupActivityService.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/PickupActivityService.java
@@ -1,7 +1,10 @@
 package com.irdaislakhuafa.garbagepickupapi.services;
 
-import com.irdaislakhuafa.garbagepickupapi.models.entities.Pickup;
+import com.irdaislakhuafa.garbagepickupapi.models.entities.PickupActivity;
+import com.irdaislakhuafa.garbagepickupapi.models.gql.request.pickupactivity.PickupActivityRequest;
+import com.irdaislakhuafa.garbagepickupapi.models.gql.request.pickupactivity.PickupActivityUpdateRequest;
 import com.irdaislakhuafa.garbagepickupapi.services.converter.CRUDService;
+import com.irdaislakhuafa.garbagepickupapi.services.converter.EntityConverterService;
 
-public interface PickupActivityService extends CRUDService<Pickup, String> {
+public interface PickupActivityService extends CRUDService<PickupActivity, String>, EntityConverterService<PickupActivity, PickupActivityRequest, PickupActivityUpdateRequest> {
 }

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/PickupActivityService.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/PickupActivityService.java
@@ -6,5 +6,10 @@ import com.irdaislakhuafa.garbagepickupapi.models.gql.request.pickupactivity.Pic
 import com.irdaislakhuafa.garbagepickupapi.services.converter.CRUDService;
 import com.irdaislakhuafa.garbagepickupapi.services.converter.EntityConverterService;
 
+import java.util.List;
+
 public interface PickupActivityService extends CRUDService<PickupActivity, String>, EntityConverterService<PickupActivity, PickupActivityRequest, PickupActivityUpdateRequest> {
+    List<PickupActivity> findAllByPickupId(final String pickupId);
+
+    List<PickupActivity> findAllByPickupResi(String pickupResi);
 }

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/impl/PickupActivityServiceImpl.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/impl/PickupActivityServiceImpl.java
@@ -79,6 +79,7 @@ public class PickupActivityServiceImpl implements PickupActivityService {
     public List<PickupActivity> findAllByPickupId(String pickupId) {
         try {
             final var results = this.pickupActivityRepository.findAllByPickupId(pickupId);
+            results.sort((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()));
             return results;
         } catch (Exception e) {
             throw new BadRequestException(e.getMessage());
@@ -89,6 +90,7 @@ public class PickupActivityServiceImpl implements PickupActivityService {
     public List<PickupActivity> findAllByPickupResi(String pickupResi) {
         try {
             final var results = this.pickupActivityRepository.findAllByPickupResi(pickupResi);
+            results.sort((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()));
             return results;
         } catch (Exception e) {
             throw new BadRequestException(e.getMessage());

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/impl/PickupActivityServiceImpl.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/impl/PickupActivityServiceImpl.java
@@ -1,39 +1,77 @@
 package com.irdaislakhuafa.garbagepickupapi.services.impl;
 
-import com.irdaislakhuafa.garbagepickupapi.models.entities.Pickup;
+import com.irdaislakhuafa.garbagepickupapi.exceptions.custom.BadRequestException;
+import com.irdaislakhuafa.garbagepickupapi.models.entities.PickupActivity;
+import com.irdaislakhuafa.garbagepickupapi.models.gql.request.pickupactivity.PickupActivityRequest;
+import com.irdaislakhuafa.garbagepickupapi.models.gql.request.pickupactivity.PickupActivityUpdateRequest;
+import com.irdaislakhuafa.garbagepickupapi.repository.PickupActivityRepository;
+import com.irdaislakhuafa.garbagepickupapi.repository.PickupRepository;
 import com.irdaislakhuafa.garbagepickupapi.services.PickupActivityService;
+import com.irdaislakhuafa.garbagepickupapi.services.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class PickupActivityServiceImpl implements PickupActivityService {
+    private final UserService userService;
+    private final PickupActivityRepository pickupActivityRepository;
+    private final PickupRepository pickupRepository;
 
     @Override
-    public Optional<Pickup> save(Pickup request) {
+    public Optional<PickupActivity> save(PickupActivity request) {
+        try {
+            request.setCreatedAt(LocalDateTime.now());
+            request.setCreatedBy(this.userService.getCurrentUser().getId());
+
+            final var result = this.pickupActivityRepository.save(request);
+            return Optional.of(result);
+        } catch (Exception e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
+
+    @Override
+    public Optional<PickupActivity> update(PickupActivity request) {
         return Optional.empty();
     }
 
     @Override
-    public Optional<Pickup> update(Pickup request) {
+    public Optional<PickupActivity> delete(String s) {
         return Optional.empty();
     }
 
     @Override
-    public Optional<Pickup> delete(String s) {
+    public Optional<PickupActivity> findById(String s) {
         return Optional.empty();
     }
 
     @Override
-    public Optional<Pickup> findById(String s) {
-        return Optional.empty();
+    public List<PickupActivity> findAll() {
+        return null;
     }
 
     @Override
-    public List<Pickup> findAll() {
+    public PickupActivity fromRequestToEntity(PickupActivityRequest request) {
+        final var pickup = this.pickupRepository.findById(request.getPickupId());
+        if (pickup.isEmpty()) {
+            throw new BadRequestException(String.format("pickup with id '%s' not found", request.getPickupId()));
+        }
+
+        final var result = PickupActivity.builder()
+                .pickup(pickup.get())
+                .description(request.getDescription())
+                .build();
+
+        return result;
+    }
+
+    @Override
+    public PickupActivity fromUpdateRequestToEntity(PickupActivityUpdateRequest request) {
         return null;
     }
 }

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/impl/PickupActivityServiceImpl.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/impl/PickupActivityServiceImpl.java
@@ -74,4 +74,24 @@ public class PickupActivityServiceImpl implements PickupActivityService {
     public PickupActivity fromUpdateRequestToEntity(PickupActivityUpdateRequest request) {
         return null;
     }
+
+    @Override
+    public List<PickupActivity> findAllByPickupId(String pickupId) {
+        try {
+            final var results = this.pickupActivityRepository.findAllByPickupId(pickupId);
+            return results;
+        } catch (Exception e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
+
+    @Override
+    public List<PickupActivity> findAllByPickupResi(String pickupResi) {
+        try {
+            final var results = this.pickupActivityRepository.findAllByPickupResi(pickupResi);
+            return results;
+        } catch (Exception e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/impl/PickupActivityServiceImpl.java
+++ b/src/main/java/com/irdaislakhuafa/garbagepickupapi/services/impl/PickupActivityServiceImpl.java
@@ -1,0 +1,39 @@
+package com.irdaislakhuafa.garbagepickupapi.services.impl;
+
+import com.irdaislakhuafa.garbagepickupapi.models.entities.Pickup;
+import com.irdaislakhuafa.garbagepickupapi.services.PickupActivityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PickupActivityServiceImpl implements PickupActivityService {
+
+    @Override
+    public Optional<Pickup> save(Pickup request) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Pickup> update(Pickup request) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Pickup> delete(String s) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Pickup> findById(String s) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Pickup> findAll() {
+        return null;
+    }
+}

--- a/src/main/resources/graphql/init.graphqls
+++ b/src/main/resources/graphql/init.graphqls
@@ -14,4 +14,5 @@ type Mutation {
     trashType: TrashTypeMutation!
     voucher: VoucherMutation!
     userVoucher: UserVoucherMutation!
+    pickupActivity: PickupActivityMutation!
 }

--- a/src/main/resources/graphql/init.graphqls
+++ b/src/main/resources/graphql/init.graphqls
@@ -5,6 +5,7 @@ type Query {
     trashType: TrashTypeQuery!
     voucher: VoucherQuery!
     userVoucher: UserVoucherQuery!
+    pickupActivity: PickupActivityQuery!
 }
 
 type Mutation {

--- a/src/main/resources/graphql/pickup.graphqls
+++ b/src/main/resources/graphql/pickup.graphqls
@@ -11,6 +11,7 @@ type PickupQuery {
 
 type Pickup {
     id: String!
+    resi: String!
     user: User!
     courier: User!
     status: PickupStatus!

--- a/src/main/resources/graphql/pickupActivity.graphqls
+++ b/src/main/resources/graphql/pickupActivity.graphqls
@@ -1,3 +1,7 @@
+type PickupActivityMutation {
+    save(request: PickupActivityRequest!): PickupActivity
+}
+
 type PickupActivity {
     id: String!
     pickup: Pickup!
@@ -9,4 +13,9 @@ type PickupActivity {
     deletedAt: String
     deletedBy: String
     isDeleted: Boolean!
+}
+
+input PickupActivityRequest {
+    pickupId: String!
+    description: String!
 }

--- a/src/main/resources/graphql/pickupActivity.graphqls
+++ b/src/main/resources/graphql/pickupActivity.graphqls
@@ -3,7 +3,10 @@ type PickupActivityMutation {
 }
 
 type PickupActivityQuery {
+    # @return default is sorted DESC by createdAt
     findAllByPickupId(pickupId: String): [PickupActivity!]
+
+    # @return default is sorted DESC by createdAt
     findAllByPickupResi(pickupResi: String!): [PickupActivity!]
 }
 

--- a/src/main/resources/graphql/pickupActivity.graphqls
+++ b/src/main/resources/graphql/pickupActivity.graphqls
@@ -2,6 +2,11 @@ type PickupActivityMutation {
     save(request: PickupActivityRequest!): PickupActivity
 }
 
+type PickupActivityQuery {
+    findAllByPickupId(pickupId: String): [PickupActivity!]
+    findAllByPickupResi(pickupResi: String!): [PickupActivity!]
+}
+
 type PickupActivity {
     id: String!
     pickup: Pickup!


### PR DESCRIPTION
# Description
this PR doesn't include mutation to update and delete PickupActivity

# Commits
- added unimplemented service for pickup activity
- added method to save new pickup activity
- added graphql mutation to save new pickup activity
- added graphql query to find list of pickup activity by pickup id and by pickup resi
- added default sort data by createdAt with DESC direction for graphql query PickupActivity (findAllByPickupId, findAllByPickupResi)
